### PR TITLE
Add version name top the top tile

### DIFF
--- a/concordia/StandardDeviationCalculator.java
+++ b/concordia/StandardDeviationCalculator.java
@@ -41,13 +41,13 @@ class StandardDeviationCalculator extends JFrame {
   private JTextField inputField;
   private JTextArea resultArea;
   private JLabel formulaLabel;
-  private static final String VERSION = "1.0.0";
+  private static final String VERSION = "1.0.1";
 
   /**
    * Constructor to set up the GUI components and layout.
    */
   public StandardDeviationCalculator() {
-    setTitle("Standard Deviation Calculator");
+    setTitle("Standard Deviation Calculator v" + VERSION);
     setSize(600, 400);
     setDefaultCloseOperation(EXIT_ON_CLOSE);
     setLayout(new BorderLayout(10, 10));


### PR DESCRIPTION
### TL;DR

Updated version number and added version to application title.

### What changed?

- Incremented version number from `1.0.0` to `1.0.1`
- Modified the application title to include the version number by appending `v` + `VERSION` to "Standard Deviation Calculator"

### How to test?

1. Launch the application
2. Verify that the window title shows "Standard Deviation Calculator v1.0.1"
3. Check that the application functions correctly with the updated title

### Why make this change?

This change makes the version number visible in the application title, improving user awareness of which version they're using. This helps with support and troubleshooting by making the version immediately identifiable from the UI.